### PR TITLE
reraise instead of break

### DIFF
--- a/telegram_bot/telegram_bot.py
+++ b/telegram_bot/telegram_bot.py
@@ -50,7 +50,7 @@ class TelegramBot:
                     await asyncio.sleep(e.retry_after)
                 except Exception as e:
                     logging.exception(log_text.format(e))
-                    break
+                    raise
 
         default_kwargs = conf['DEFAULT_KWARGS'](function)
         kwargs = {**default_kwargs, **kwargs}


### PR DESCRIPTION
if there is something wrong so we can catch the error

        try:
            bot.send_raw(chat_id=chat_id, text=report_text, parse_mode="HTML")
            bot.send_raw(chat_id=chat_id, function="send_document", document=types.FSInputFile(pdf_report))
            logger.info(f"tg report {scheduled_report.name} has been send to {recipient}")
        except Exception as e:
            error_msg = str(e)
            bot.send_raw(CHAT_ID, text=f"{report_text}\n\n{e}", parse_mode="HTML")
            logger.info(f"{e}\ntg report {scheduled_report.name} has NOT been send to {recipient}")